### PR TITLE
Fixed String#snakecase Method

### DIFF
--- a/lib/Data/Object/String/Func/Snakecase.pm
+++ b/lib/Data/Object/String/Func/Snakecase.pm
@@ -26,10 +26,11 @@ sub execute {
 
   my ($data) = $self->unpack;
 
-  my $result = lc("$data");
+  my $result = "$data";
 
-  $result =~ s/[^a-zA-Z0-9]+([a-z])/\U$1/g;
-  $result =~ s/[^a-zA-Z0-9]+//g;
+  my $re = qr/[\W_]+/;
+  $result =~ s/$re/_/g;
+  $result =~ s/^$re|$re$//g;
 
   return $result;
 }

--- a/t/0.01/data/object/string/snakecase.t
+++ b/t/0.01/data/object/string/snakecase.t
@@ -13,7 +13,7 @@ subtest 'test the snakecase method' => sub {
   my $snakecase = $string->snakecase;
 
   isnt refaddr($string), refaddr($snakecase);
-  is "$snakecase", 'helloWorld';    # helloWorld
+  is "$snakecase", 'hello_world';    # hello_world
 
   isa_ok $string,    'Data::Object::String';
   isa_ok $snakecase, 'Data::Object::String';

--- a/t/0.90/can/Data_Object_String_Func_Snakecase_execute.t
+++ b/t/0.90/can/Data_Object_String_Func_Snakecase_execute.t
@@ -2,6 +2,7 @@ use 5.014;
 
 use strict;
 use warnings;
+use utf8;
 
 use Test::More;
 
@@ -42,16 +43,32 @@ use Data::Object::String::Func::Snakecase;
 
 can_ok "Data::Object::String::Func::Snakecase", "execute";
 
-my $data;
-my $func;
-
-$data = Data::Object::String->new("hello world");
-$func = Data::Object::String::Func::Snakecase->new(
-  arg1 => $data
+my %tests = (
+  'hello world'   => 'hello_world',
+  'hello  world'  => 'hello_world',
+  'helloWorld'    => 'helloWorld',
+  'hello-world'   => 'hello_world',
+  'helloworld'    => 'helloworld',
+  'Hello, World!' => 'Hello_World',
+  'Helló, Wörld!' => 'Helló_Wörld',
+  'foo, _bar_!'   => 'foo_bar',
+  '__'            => '',
+  ''              => '',
 );
 
-my $result = $func->execute;
+for my $in (keys %tests) {
+  my $out = $tests{$in};
+  my $data;
+  my $func;
 
-is_deeply $result, 'helloWorld';
+  $data = Data::Object::String->new($in);
+  $func = Data::Object::String::Func::Snakecase->new(
+    arg1 => $data
+  );
+
+  my $result = $func->execute;
+
+  is_deeply $result, $out, $in;
+}
 
 ok 1 and done_testing;

--- a/t/0.90/can/Data_Object_String_snakecase.t
+++ b/t/0.90/can/Data_Object_String_snakecase.t
@@ -15,16 +15,15 @@ snakecase
 
   # given 'hello world'
 
-  $string->snakecase; # helloWorld
+  $string->snakecase; # hello_world
 
 =description
 
 The snakecase method modifies the string such that it will no longer have any
-non-alphanumeric characters and each word (group of alphanumeric characters
-separated by 1 or more non-alphanumeric characters) is capitalized. The only
-difference between this method and the camelcase method is that this method
-ensures that the first character will always be lowercased. Note, this method
-modifies the string. This method returns a string value.
+non-alphanumeric characters and all words (groups of alphanumeric characters
+separated by 1 or more non-alphanumeric characters) are joined by a single
+underscore. This method returns a string value. Any leading or trailing
+underscores are removed.
 
 =signature
 
@@ -42,6 +41,6 @@ use_ok 'Data::Object::String';
 
 my $data = Data::Object::String->new('hello world');
 
-is_deeply $data->snakecase(), 'helloWorld';
+is_deeply $data->snakecase(), 'hello_world';
 
 ok 1 and done_testing;


### PR DESCRIPTION
The snakecase method was returning "pascal case"
(eg. "helloWorld") rather than "snake case"
(eg. "hello_world"). This is now fixed.

Closes #253.